### PR TITLE
fix: count may be zero

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,5 +27,5 @@ module.exports = (word, plural, count) => {
 			});
 	}
 
-	return Math.abs(count) === 1 ? word : plural;
+	return Math.abs(count) <= 1 ? word : plural;
 };


### PR DESCRIPTION
```js
plur( 'unicorn', 0 )
```

Expected: unicorn
Actual: unicorns