### PR TITLE
Remove moot `.toUpperCase()` call

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ export default function plur(word, plural, count) {
 		const firstLetter = word.charAt(0);
 		const isFirstLetterUpperCase = firstLetter === firstLetter.toUpperCase();
 		if (isFirstLetterUpperCase) {
-			plural = firstLetter.toUpperCase() + plural.slice(1);
+			plural = firstLetter + plural.slice(1);
 		}
 
 		const isWholeWordUpperCase = word === word.toUpperCase();


### PR DESCRIPTION
since we checked already whether the letter is upperCase, and the condition is true, we don't have to call explicitly toUpperCase() anymore.