### PR TITLE
Update type defs to allow a single param

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -19,6 +19,9 @@ Default:
 ```
 import plur from 'plur';
 
+plur('rainbow');
+//=> 'rainbows'
+
 plur('unicorn', 4);
 //=> 'unicorns'
 
@@ -32,5 +35,5 @@ plur('cactus', 2);
 //=> 'cacti'
 ```
 */
-export default function plur(word: string, count: number): string;
+export default function plur(word: string, count?: number): string;
 export default function plur(word: string, plural: string, count: number): string;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,6 @@
 import {expectType} from 'tsd';
 import plur from './index.js';
 
+expectType<string>(plur('chicken'));
 expectType<string>(plur('chicken', 2));
 expectType<string>(plur('chicken', 'chicks', 2));

--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,9 @@ npm install plur
 ```js
 import plur from 'plur';
 
+plur('rainbow');
+//=> 'rainbows'
+
 plur('unicorn', 4);
 //=> 'unicorns'
 

--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,7 @@ plur('cactus', 2);
 
 ## API
 
-### plur(word, plural?, count)
+### plur(word, plural?, count?)
 
 #### word
 
@@ -59,4 +59,4 @@ This option is only for extreme edge-cases. You probably won't need it.
 
 Type: `number`
 
-The count to determine whether to use singular or plural.
+The count to determine whether to use singular or plural. If omitted, defaults to plural.

--- a/test.js
+++ b/test.js
@@ -2,6 +2,7 @@ import test from 'ava';
 import plur from './index.js';
 
 test('main', t => {
+	t.is(plur('unicorn'), 'unicorns');
 	t.is(plur('unicorn', 0), 'unicorns');
 	t.is(plur('unicorn', 1), 'unicorn');
 	t.is(plur('unicorn', 2), 'unicorns');


### PR DESCRIPTION
Just makes the second param optional in the type def. Also adds a bit to the docs showing how it can be used with a single param.